### PR TITLE
Update Lucid Air generations: Added Wikipedia reference and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Lucid Air
 
+This repository contains signal set configurations for the Lucid Air, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Lucid Air.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Lucid_Air"
+
 generations:
   - name: "First Generation"
     start_year: 2021


### PR DESCRIPTION
- Added references array with Wikipedia article URL
- Updated README.md with standard template
- Verified single generation (2021-present) from Wikipedia article
- Production began late 2021, deliveries started October 30, 2021
